### PR TITLE
Automate gratuity recalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
 # Prueba2
 
-Pre informe auditoria laboral
+Este repositorio contiene los papeles de trabajo y reportes utilizados en la auditoría de gratificaciones 2024 para Prosegur. Incluye:
 
-Este repositorio contiene el pre informe de auditoria actualizado con los hallazgos y recomendaciones derivados del analisis de gratificacion 2024.
+- **Analisis Gratificacion 2024 - Prosegur V1.xlsx**: libro principal con hojas de detalle de remuneraciones, factores de corrección y cálculos del cliente.
+- **PROSEGUR CHILE.xlsx**, **PROSEGUR LTDA.xlsx**, **PROSEGUR REGIONES.xlsx**, **SERVICIOS PROSEGUR.xlsx**: libros de remuneraciones electrónicos de las distintas sociedades.
+- **3.2.5 ... Renta Liquida Imponoble**: determinaciones tributarias con la utilidad a repartir.
+- **pmoralesto,+Gestor_a+de+la+revista,+RET+23+-+GRATIFICACIONES.pdf**: artículo de referencia de la FEN.
+- **pre-informe Gratificacion Prosegur.docx**: borrador del informe de auditoría.
+
+## Automatización del recálculo
+
+Se añadió el script `recalculo_gratificacion.py` que permite procesar todo el detalle de remuneraciones y calcular la gratificación de acuerdo con los artículos 47 o 50 del Código del Trabajo. El resultado se compara con el anticipo pagado por el cliente.
+
+### Requisitos
+
+```bash
+pip install -r requirements.txt
+```
+
+### Uso
+
+```bash
+python recalculo_gratificacion.py \
+    --file "Analisis Gratificacion 2024 - Prosegur V1.xlsx" \
+    --profit 100000000 \
+    --min-wage 460000 \
+    --output resultados.csv
+```
+
+- `--profit` corresponde a la utilidad líquida del ejercicio para distribuir bajo artículo 47.
+- `--min-wage` define el sueldo mínimo para el tope del artículo 50.
+
+El archivo generado `resultados.csv` incluye por cada empleado su total imponible anual, gratificación pagada, gratificación recalculada y la diferencia.
+
+### Dashboard
+
+Con `streamlit` se puede ejecutar una interfaz interactiva:
+
+```bash
+streamlit run dashboard.py
+```
+
+Allí se ingresan los parámetros y se visualiza un resumen de diferencias y los colaboradores con cambio de empleador.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,35 @@
+import streamlit as st
+import pandas as pd
+from recalculo_gratificacion import load_workbook, classify_employees, compute_totals, recalc_art47, recalc_art50
+
+st.title('Recalculo de Gratificaciones')
+
+excel_file = st.text_input('Archivo Excel', 'Analisis Gratificacion 2024 - Prosegur V1.xlsx')
+profit = st.number_input('Utilidades líquidas para Art 47', value=0.0)
+min_wage = st.number_input('Salario mínimo', value=460000.0)
+
+if st.button('Procesar'):
+    detalle, art47_df, art50_df = load_workbook(excel_file)
+    art47_ids, art50_ids = classify_employees(art47_df, art50_df)
+    totals = compute_totals(detalle)
+    totals['LEGAJO_STR'] = totals['LEGAJO'].astype(str)
+
+    art47_mask = totals['LEGAJO_STR'].isin(art47_ids)
+    art50_mask = totals['LEGAJO_STR'].isin(art50_ids)
+
+    art47_totals = recalc_art47(totals[art47_mask].copy(), profit)
+    art50_totals = recalc_art50(totals[art50_mask].copy(), min_wage)
+
+    results = pd.concat([art47_totals, art50_totals])
+    results['Articulo'] = results['LEGAJO_STR'].apply(lambda x: '47' if x in art47_ids else '50')
+    results['Diferencia'] = results['Recalculo'] - results['Grat_pagada']
+
+    st.write('Resumen de Resultados')
+    st.dataframe(results[['EMPRESA','LEGAJO','Total Imponible','Grat_pagada','Recalculo','Diferencia','Articulo']])
+
+    total_diff = results['Diferencia'].sum()
+    st.metric('Diferencia Total', total_diff)
+
+    cambios = results[results['Motivo de Egreso']]
+    st.subheader('Colaboradores con cambio de empleador')
+    st.dataframe(cambios[['EMPRESA','LEGAJO','Diferencia']])

--- a/recalculo_gratificacion.py
+++ b/recalculo_gratificacion.py
@@ -1,0 +1,75 @@
+import argparse
+import pandas as pd
+
+
+def load_workbook(path):
+    xl = pd.ExcelFile(path)
+    detalle = xl.parse('Detalle Remun 2024')
+    art47 = xl.parse('Calculo PPC Art47', header=1)
+    art50 = xl.parse('Calculo PPC Art50', skiprows=2)
+    return detalle, art47, art50
+
+
+def classify_employees(art47_df, art50_df):
+    art47_ids = set(art47_df['LEGAJO'].dropna().astype(int).astype(str))
+    art50_ids = set(art50_df['LEGAJO'].dropna().astype(int).astype(str))
+    return art47_ids, art50_ids
+
+
+def compute_totals(detalle):
+    detalle['LEGAJO'] = detalle['LEGAJO'].astype(str)
+    grouped = detalle.groupby(['EMPRESA', 'LEGAJO'])
+    totals = grouped.agg({
+        'Total Imponible': 'sum',
+        'Grat anticipada': 'sum',
+        'dias Trabajados': 'sum',
+        'Motivo de Egreso': lambda x: x.notna().any()
+    }).reset_index()
+    totals.rename(columns={'Grat anticipada': 'Grat_pagada', 'dias Trabajados': 'Dias_trab'}, inplace=True)
+    return totals
+
+
+def recalc_art47(subset, profit):
+    base = profit * 0.30
+    total_imponible = subset['Total Imponible'].sum()
+    if total_imponible == 0:
+        return pd.Series(dtype=float)
+    factor = base / total_imponible
+    subset['Recalculo'] = subset['Total Imponible'] * factor
+    return subset
+
+
+def recalc_art50(subset, min_wage):
+    subset['Recalculo'] = (subset['Total Imponible'] * 0.25).clip(upper=4.75 * min_wage)
+    return subset
+
+
+def main(path, profit, min_wage, output):
+    detalle, art47_df, art50_df = load_workbook(path)
+    art47_ids, art50_ids = classify_employees(art47_df, art50_df)
+
+    totals = compute_totals(detalle)
+    totals['LEGAJO_STR'] = totals['LEGAJO'].astype(str)
+
+    art47_mask = totals['LEGAJO_STR'].isin(art47_ids)
+    art50_mask = totals['LEGAJO_STR'].isin(art50_ids)
+
+    art47_totals = recalc_art47(totals[art47_mask].copy(), profit)
+    art50_totals = recalc_art50(totals[art50_mask].copy(), min_wage)
+
+    results = pd.concat([art47_totals, art50_totals])
+    results['Articulo'] = results['LEGAJO_STR'].apply(lambda x: '47' if x in art47_ids else '50')
+    results['Diferencia'] = results['Recalculo'] - results['Grat_pagada']
+
+    results[['EMPRESA', 'LEGAJO', 'Total Imponible', 'Grat_pagada', 'Recalculo',
+             'Diferencia', 'Dias_trab', 'Motivo de Egreso', 'Articulo']].to_csv(output, index=False)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Recalculo de gratificaciones')
+    parser.add_argument('--file', default='Analisis Gratificacion 2024 - Prosegur V1.xlsx', help='Workbook path')
+    parser.add_argument('--profit', type=float, default=0.0, help='Utilidades liquidas para repartir Art 47')
+    parser.add_argument('--min-wage', type=float, default=460000.0, help='Salario minimo para Art 50')
+    parser.add_argument('--output', default='recalculo_resultados.csv')
+    args = parser.parse_args()
+    main(args.file, args.profit, args.min_wage, args.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+openpyxl
+streamlit


### PR DESCRIPTION
## Summary
- create `recalculo_gratificacion.py` script to process payroll data
- add Streamlit `dashboard.py` for interactive recalculation
- document usage in README
- add `requirements.txt`

## Testing
- `python recalculo_gratificacion.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684b73deba38832b942068730d82b69c