### PR TITLE
Automated hallazgos workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ streamlit run dashboard.py
 ```
 
 Allí se ingresan los parámetros y se visualiza un resumen de diferencias y los colaboradores con cambio de empleador.
+
+### Macros y hoja de hallazgos
+
+Se agregó el script `update_hallazgos.py` que obtiene las utilidades de las determinaciones tributarias, ejecuta el recálculo y actualiza el libro principal creando la hoja **Hallazgos**. Para ejecutar este proceso desde Excel se incluye el módulo `recalculo_macros.bas` con la macro `ActualizarHallazgos`.
+
+1. Instalar los requisitos y ubicar `python` en el PATH.
+2. Importar `recalculo_macros.bas` en el archivo `Analisis Gratificacion 2024 - Prosegur V1.xlsx` y ejecutar `ActualizarHallazgos`.
+
+La macro ejecuta el script Python y en la hoja "Hallazgos" se muestran las diferencias por trabajador.

--- a/recalculo_macros.bas
+++ b/recalculo_macros.bas
@@ -1,0 +1,8 @@
+Attribute VB_Name = "Recalculo"
+Option Explicit
+
+Sub ActualizarHallazgos()
+    Dim py As String
+    py = ThisWorkbook.Path & "\update_hallazgos.py"
+    Shell "python """ & py & """", vbNormalFocus
+End Sub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 openpyxl
 streamlit
+xlwings

--- a/update_hallazgos.py
+++ b/update_hallazgos.py
@@ -1,0 +1,46 @@
+import csv
+import pandas as pd
+import openpyxl
+from recalculo_gratificacion import main as recalc_main
+
+RLI_FILES = [
+    '3.2.5 78570410-K Renta Liquida Imponoble y determinación 30%.xlsx',
+    '3.2.5 96514060-3 Renta Liquida Imponoble y determinación 30%.xlsx'
+]
+
+
+def extract_profit(path: str) -> float:
+    """Extract profit from Renta Liquida workbook."""
+    df = pd.read_excel(path, sheet_name='Utilidad Liquida', header=None)
+    row = df[df.apply(lambda r: r.astype(str).str.contains('Reparto Utilidades').any(), axis=1)].iloc[0]
+    profit_30 = row[5] if not pd.isna(row[5]) else row[8]
+    return float(profit_30) / 0.30
+
+
+def gather_profit(paths) -> float:
+    return sum(extract_profit(p) for p in paths)
+
+
+def update_hallazgos(excel_path: str, profit: float, min_wage: float = 460000.0):
+    temp_csv = 'hallazgos_temp.csv'
+    recalc_main(excel_path, profit, min_wage, output=temp_csv)
+
+    wb = openpyxl.load_workbook(excel_path)
+    if 'Hallazgos' in wb.sheetnames:
+        del wb['Hallazgos']
+    ws = wb.create_sheet('Hallazgos')
+    with open(temp_csv, newline='') as f:
+        reader = csv.reader(f)
+        for r_idx, row in enumerate(reader, 1):
+            for c_idx, value in enumerate(row, 1):
+                ws.cell(row=r_idx, column=c_idx, value=value)
+    wb.save(excel_path)
+
+
+def main():
+    profit = gather_profit(RLI_FILES)
+    update_hallazgos('Analisis Gratificacion 2024 - Prosegur V1.xlsx', profit)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script `update_hallazgos.py` to compute profit from the RLI workbooks, run the recalc and update the main spreadsheet with a new sheet `Hallazgos`
- add VBA module `recalculo_macros.bas` that runs the Python script from Excel
- document macro usage in README
- add `xlwings` to requirements

## Testing
- `pip install xlwings`
- `pip install openpyxl pandas`
- ⚠️ `python update_hallazgos.py` (interrupted due to long execution)


------
https://chatgpt.com/codex/tasks/task_e_684b92539808832b827ae3aa9e6313c2